### PR TITLE
Fixing the incorrect queue behaviour

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -78,9 +78,9 @@ func (q *Queue) Pop() (interface{}, bool) {
 
 	q.lock.Lock()
 	c := q.content
-	c.head++
+	c.head = ((c.head+1)%c.mod)
 	//h := atomic.AddInt64(&c.head, 1)
-	res := c.buffer[c.head%c.mod]
+	res := c.buffer[c.head]
 	q.len--
 	//atomic.AddInt64(&q.len, -1)
 	q.lock.Unlock()

--- a/queue_test.go
+++ b/queue_test.go
@@ -49,3 +49,27 @@ func TestPushPopMany2(t *testing.T) {
 	}
 	assert.True(t, q.Empty())
 }
+func TestExpand(t *testing.T) {
+        q := New(10)
+        for i := 0; i < 90000; i++ {
+                item := fmt.Sprintf("hello%v", i)
+                q.Push(item)
+        }
+        for i := 0; i < 1000; i++ {
+                item := fmt.Sprintf("hello%v", i)
+                res, _ := q.Pop()
+                assert.Equal(t, item, res)
+        }
+        for i := 0; i < 500; i++ {
+                item := fmt.Sprintf("hello%v", i+9000)
+                q.Push(item)
+        }
+        for i := 0; i < 8500; i++ {
+                item := fmt.Sprintf("hello%v", i+1000)
+                res, _ := q.Pop()
+                assert.Equal(t, item, res)
+        }
+
+        assert.True(t, q.Empty())
+}
+


### PR DESCRIPTION
The latest commit modified head pointer so it does not wrap around
anymore. This is problematic, since head can pass tail pointer and
since in 'Push' head is being compared to tail, this can create
issues when the buffer is expanded and then values are popped from
the queue. The problem is that then the tail never gets equal to
head, and both tail and head (not the number but the value that is being popped from) wrap around, which can result in overwrites or duplicate messages popped form the queue.
I added a test to verify this does not happen after other changes. 